### PR TITLE
feature/horizontalgauge-format-tooltip/#45

### DIFF
--- a/src/components/gauges/HorizontalGauge.jsx
+++ b/src/components/gauges/HorizontalGauge.jsx
@@ -7,6 +7,7 @@ import './HorizontalGauge.scss';
 let stackPropType = PropTypes.shape({
   label: PropTypes.string.isRequired,
   value: PropTypes.number.isRequired,
+  display: PropTypes.node,
   color: PropTypes.string.isRequired
 });
 
@@ -24,7 +25,7 @@ const HorizontalGauge = React.createClass({
      *  * blank space is the `all` stack
      */
     all: stackPropType.isRequired,
-    stacks: PropTypes.arrayOf(stackPropType).isRequired
+    stacks: PropTypes.arrayOf(stackPropType).isRequired,
   },
 
   getInitialState() {
@@ -49,8 +50,8 @@ const HorizontalGauge = React.createClass({
     let { stacks, all } = this.props;
     return (
       <TooltipTable
-        groups={[[all.label, all.value]]}
-        metrics={stacks.map((stack) => [stack.label, stack.value])}
+        groups={[[all.label, all.display || all.value]]}
+        metrics={stacks.map((stack) => [stack.label, stack.display || stack.value])}
       />
     );
   },

--- a/src/components/gauges/HorizontalGauge.jsx
+++ b/src/components/gauges/HorizontalGauge.jsx
@@ -26,6 +26,15 @@ const HorizontalGauge = React.createClass({
      */
     all: stackPropType.isRequired,
     stacks: PropTypes.arrayOf(stackPropType).isRequired,
+    formatAllValue: PropTypes.func,
+    formatStackValue: PropTypes.func,
+  },
+
+  getDefaultProps() {
+    return {
+      formatAllValue: v => `${v}`,
+      formatStackValue: v => `${v}`
+    };
   },
 
   getInitialState() {
@@ -47,11 +56,11 @@ const HorizontalGauge = React.createClass({
   },
 
   _renderTooltip() {
-    let { stacks, all } = this.props;
+    let { stacks, all, formatAllValue, formatStackValue } = this.props;
     return (
       <TooltipTable
-        groups={[[all.label, all.display || all.value]]}
-        metrics={stacks.map((stack) => [stack.label, stack.display || stack.value])}
+        groups={[[all.label, formatAllValue(all.value)]]}
+        metrics={stacks.map((stack) => [stack.label, formatStackValue(stack.value)])}
       />
     );
   },

--- a/test/HorizontalGauge.spec.jsx
+++ b/test/HorizontalGauge.spec.jsx
@@ -11,6 +11,7 @@ describe('HorizontalGauge', () => {
     {
       label: 'Stack 1',
       color: 'red',
+      display: <div className="display">25.00</div>,
       value: 25
     },
     {
@@ -37,6 +38,17 @@ describe('HorizontalGauge', () => {
     TestUtils.SimulateNative.mouseOut(gaugeNode);
     tooltips = TestUtils.scryRenderedComponentsWithType(gauge, Tooltip);
     expect(tooltips.length).toBe(0);
+    unmount(gauge);
+  });
+
+  it('should display a stack\'s `display` property, if defined, instead of its `value`', () => {
+    let gauge = render(<HorizontalGauge stacks={stacks} all={all} />);
+    let gaugeNode = React.findDOMNode(TestUtils.findRenderedDOMComponentWithClass(gauge, 'HorizontalGauge'));
+    TestUtils.SimulateNative.mouseOver(gaugeNode);
+    let display = TestUtils.scryRenderedDOMComponentsWithClass(gauge, 'display');
+    expect(display.length).toBe(1);
+    let displayNode = React.findDOMNode(display[0]);
+    expect(displayNode.innerText).toBe('25.00');
     unmount(gauge);
   });
 

--- a/test/HorizontalGauge.spec.jsx
+++ b/test/HorizontalGauge.spec.jsx
@@ -11,13 +11,12 @@ describe('HorizontalGauge', () => {
     {
       label: 'Stack 1',
       color: 'red',
-      display: <div className="display">25.00</div>,
       value: 25
     },
     {
       label: 'Stack 2',
       color: 'red',
-      value: 25
+      value: 50
     }
   ];
   let all = {
@@ -41,14 +40,40 @@ describe('HorizontalGauge', () => {
     unmount(gauge);
   });
 
-  it('should display a stack\'s `display` property, if defined, instead of its `value`', () => {
-    let gauge = render(<HorizontalGauge stacks={stacks} all={all} />);
+  it('should pass stacks `value` properties through the `formatStackValue` prop before rendering them', () => {
+    let gauge = render(
+      <HorizontalGauge
+        stacks={stacks}
+        all={all}
+        formatStackValue={v => <div className="formatted">{v.toFixed(2)}</div>}
+        />
+    );
     let gaugeNode = React.findDOMNode(TestUtils.findRenderedDOMComponentWithClass(gauge, 'HorizontalGauge'));
     TestUtils.SimulateNative.mouseOver(gaugeNode);
-    let display = TestUtils.scryRenderedDOMComponentsWithClass(gauge, 'display');
-    expect(display.length).toBe(1);
-    let displayNode = React.findDOMNode(display[0]);
-    expect(displayNode.innerText).toBe('25.00');
+    let formatted = TestUtils.scryRenderedDOMComponentsWithClass(gauge, 'formatted');
+    expect(formatted.length).toBe(2);
+    let formattedNode1 = React.findDOMNode(formatted[0]);
+    expect(formattedNode1.innerText).toBe('25.00');
+    let formattedNode2 = React.findDOMNode(formatted[1]);
+    expect(formattedNode2.innerText).toBe('50.00');
+    unmount(gauge);
+  });
+
+
+  it('should pass the all stack\'s `value` property through the `formatAllValue` prop before rendering it', () => {
+    let gauge = render(
+      <HorizontalGauge
+        stacks={stacks}
+        all={all}
+        formatAllValue={v => <div className="formatted">{v.toFixed(2)}</div>}
+        />
+    );
+    let gaugeNode = React.findDOMNode(TestUtils.findRenderedDOMComponentWithClass(gauge, 'HorizontalGauge'));
+    TestUtils.SimulateNative.mouseOver(gaugeNode);
+    let formatted = TestUtils.scryRenderedDOMComponentsWithClass(gauge, 'formatted');
+    expect(formatted.length).toBe(1);
+    let formattedNode = React.findDOMNode(formatted[0]);
+    expect(formattedNode.innerText).toBe('100.00');
     unmount(gauge);
   });
 


### PR DESCRIPTION
I hesitated between passing a function that returns a node (formatValue => ReactNode) and directly passing a node. A node is any object React can render (ReactElement/String/Array<ReactElement>/etc.).

I went with passing a node as the `display` property on stacks props. @zallek thoughts?
